### PR TITLE
Fix path in base url being stripped when no trailing slash

### DIFF
--- a/framework/configuration/core.py
+++ b/framework/configuration/core.py
@@ -4,7 +4,7 @@ __all__ = ["CoreConfiguration", "DEFAULT_CONFIGURATION_FILE_PATHS"]
 from pathlib import Path
 from typing import Literal
 
-from pydantic import HttpUrl, NonNegativeFloat, NonNegativeInt, SecretStr
+from pydantic import HttpUrl, NonNegativeFloat, NonNegativeInt, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 DEFAULT_CONFIGURATION_FILE_PATHS: tuple[Path, ...] = (Path("agent.toml"), Path("/etc/observability/agent.toml"))
@@ -23,3 +23,10 @@ class CoreConfiguration(BaseSettings):
     max_channel_capacity: NonNegativeInt = 0
     # in seconds
     heartbeat_period: NonNegativeFloat = 60.0
+
+    @field_validator("observability_base_url", mode="before")
+    @classmethod
+    def url_append_slash(cls, base_url: str) -> str:
+        if base_url:
+            return base_url if str(base_url).endswith('/') else f"{base_url}/"
+        return base_url

--- a/testlib/configurations/fixtures/common.py
+++ b/testlib/configurations/fixtures/common.py
@@ -28,7 +28,7 @@ def core_config_data():
         "agent_type": "databricks",
         # No assigned meaning.
         "observability_service_account_key": "2wfLQIxdpeEBBULxnVqxODaKK2-o97WuqgOZxN2ex3d4JEwnMayp_oK55xZE8w31sgdL8f2Smpn3lUGv_Msiep7gm5BB7FzO",
-        "observability_base_url": "https://test.domain.com/",
+        "observability_base_url": "https://test.domain.com/api",
         "log_level": "warning",
         "agent_key": "agent test key",
     }

--- a/testlib/configurations/validators/data.py
+++ b/testlib/configurations/validators/data.py
@@ -4,5 +4,5 @@ from framework.configuration import CoreConfiguration
 def check_all_core_config(data: dict, actual: CoreConfiguration) -> None:
     assert data["agent_type"] == actual.agent_type
     assert data["observability_service_account_key"] == actual.observability_service_account_key.get_secret_value()
-    assert data["observability_base_url"] == str(actual.observability_base_url)
+    assert data["observability_base_url"] + "/" == str(actual.observability_base_url)
     assert data["log_level"] == str(actual.log_level)


### PR DESCRIPTION
Fixes #5 

httpx.URL.join is used to generate the full API URLs from the base URL and relative path. But it's behavior is like this:
```
httpx.URL("http://xyz.com/api").join("events")
-> http://xyz.com/events

httpx.URL("http://xyz.com/api/").join("events")
-> http://xyz.com/api/events
```
This change makes sure that the trailing slash is always appended after reading the base URL from configuration.